### PR TITLE
Implementation of downloading torrent files in Go

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"net/http"
 	"io"
+	"io/ioutil"
 )
 
 var (
@@ -33,7 +34,6 @@ func receiveTorrent(bot telegramClient, client torrentClient, ud messageWrapper,
 	if ud.Document.FileID == "" {
 		return // has no document
 	}
-
 	// get the file ID and make the config
 	fconfig := tgbotapi.FileConfig{
 		FileID: ud.Document.FileID,
@@ -44,7 +44,7 @@ func receiveTorrent(bot telegramClient, client torrentClient, ud messageWrapper,
 		return
 	}
 	// downloading file on Go side (not in Transmission) because of Transmission does not support proxy
-	out, err := os.Create(file.FileID)
+	out, err := ioutil.TempFile("",file.FileID);
 	if err != nil  {
 		send(bot, fmt.Sprintf("*ERROR*: `%s`", err.Error()), ud.Chat.ID, true)
 		return
@@ -73,7 +73,7 @@ func receiveTorrent(bot telegramClient, client torrentClient, ud messageWrapper,
 	}
 
 	// add by local file
-	addTorrentByFile(bot, client, ud,file.FileID)
+	addTorrentByFile(bot, client, ud,out.Name())
 }
 
 // stop takes id[s] of torrent[s] or 'all' to stop them

--- a/insterfaces.go
+++ b/insterfaces.go
@@ -31,6 +31,7 @@ type torrentClient interface {
 	GetTorrent(int) (*transmission.Torrent, error)
 	GetStats() (*transmission.Stats, error)
 	AddByURL(url string) (transmission.TorrentAdded, error)
+	AddByLocalFile(path string) (transmission.TorrentAdded, error)
 	SetSort(transmission.Sorting)
 
 	Version() string

--- a/transmission.go
+++ b/transmission.go
@@ -15,6 +15,14 @@ func (client transmissionClient) AddByURL(url string) (transmission.TorrentAdded
 	return client.client.ExecuteAddCommand(cmd)
 }
 
+func (client transmissionClient) AddByLocalFile(localPath string) (transmission.TorrentAdded, error) {
+	cmd,err := transmission.NewAddCmdByFile(localPath)
+	if (err!=nil){
+		return transmission.TorrentAdded{},err;
+	}
+	return client.client.ExecuteAddCommand(cmd)
+}
+
 func (client transmissionClient) GetStats() (*transmission.Stats, error) {
 	return client.client.GetStats()
 }


### PR DESCRIPTION
Now bot delegates downloading of torrent files to Transmission by passing URL of file on Telegram server to Transmission. 
But if Telegram is blocked in the country (Russia for example) then Transmission fails to download. And there is no option to fix it on Transmission's side, due to limitation,  Transmission does not support proxies. One option to fix it - download it on bot side, because of bot communicating with Telegram in any case (through proxy or direct connection, it does not matter).